### PR TITLE
Expand empty methods in Ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ Style/TrailingCommaInLiteral:
   
 Metrics/LineLength:
   Max: 100
+
+EmptyMethod:
+  EnforcedStyle: expanded


### PR DESCRIPTION
The current standard is `def index; end`, while for the sake of git history, I believe it should instead be:
```ruby
def index
end
```