### PR TITLE
Fix a couple of issues when running Lintron locally

### DIFF
--- a/app/controllers/local_lints_controller.rb
+++ b/app/controllers/local_lints_controller.rb
@@ -4,7 +4,7 @@ class LocalLintsController < ApplicationController
   skip_before_action :verify_authenticity_token, if: :json_request?
 
   def create
-    pr = LocalPrAlike.from_json(params[:files])
+    pr = LocalPrAlike.from_json(params)
     violations = Linters.violations_for_pr(pr)
 
     render json: violations

--- a/lib/lintron/api.rb
+++ b/lib/lintron/api.rb
@@ -43,6 +43,8 @@ module Lintron
   # (2) I can define file_and_line which is used for display and sorting
   class ViolationLine < OpenStruct
     def file_and_line(padTo = 0)
+      return ' ' * padTo unless path && line
+
       file_and_line = "#{path}:#{format '%03i', line}    "
 
       if padTo > file_and_line.length

--- a/lib/lintron/cli.rb
+++ b/lib/lintron/cli.rb
@@ -48,7 +48,7 @@ module Lintron
     end
 
     def pr
-      LocalPrAlike.from_branch(base_branch)
+      LocalPrAlike.from_branch(org_name, repo_name, base_branch)
     end
 
     def base_branch
@@ -87,7 +87,7 @@ module Lintron
     end
 
     def config_from_file
-      file_path = File.join(`git rev-parse --show-toplevel`.strip, '.linty_rc')
+      file_path = File.join(repo_path, '.linty_rc')
 
       raise('.linty_rc is missing.') unless File.exist?(file_path)
 
@@ -96,6 +96,30 @@ module Lintron
       rescue JSON::ParserError
         raise('Malformed .linty_rc')
       end
+    end
+
+    def repo_name
+      info = origin_info
+      info ? info[:repo] : Pathname(repo_path).basename
+    end
+
+    def org_name
+      info = origin_info
+      info ? info[:org] : 'local'
+    end
+
+    def repo_path
+      `git rev-parse --show-toplevel`.strip
+    end
+
+    def origin_info
+      origin = `git config --get remote.origin.url`
+      return nil unless origin && origin.split('/').length > 1
+      path_parts = origin.split('/')
+      {
+        org: path_parts[-2],
+        repo: path_parts[-1],
+      }
     end
   end
 end

--- a/lib/lintron/cli.rb
+++ b/lib/lintron/cli.rb
@@ -113,13 +113,17 @@ module Lintron
     end
 
     def origin_info
-      origin = `git config --get remote.origin.url`
+      origin = git_origin
       return nil unless origin && origin.split('/').length > 1
-      path_parts = origin.split('/')
+      path_parts = origin.split(%r{/|:})
       {
         org: path_parts[-2],
-        repo: path_parts[-1],
+        repo: File.basename(path_parts[-1], '.*'),
       }
+    end
+
+    def git_origin
+      `git config --get remote.origin.url`.strip
     end
   end
 end

--- a/spec/lib/lintron/cli_spec.rb
+++ b/spec/lib/lintron/cli_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'lintron/cli'
+
+describe Lintron::CLI do
+  describe '#origin_info' do
+    let(:cli) do
+      Lintron::CLI.new
+    end
+
+    before do
+      allow_any_instance_of(OptionParser).to receive(:parse!)
+    end
+
+    it 'should return nil if no git origin' do
+      allow(cli).to receive(:git_origin).and_return('')
+      expect(cli.origin_info).to be nil
+    end
+
+    it 'should work with github ssh origin' do
+      allow(cli).to receive(:git_origin).and_return('git@github.com:prehnRA/lintron.git')
+      expect(cli.origin_info[:repo]).to eq 'lintron'
+      expect(cli.origin_info[:org]).to eq 'prehnRA'
+    end
+
+    it 'should work with github readonly origin' do
+      allow(cli).to receive(:git_origin).and_return('git://github.com/prehnRA/lintron.git')
+      expect(cli.origin_info[:repo]).to eq 'lintron'
+      expect(cli.origin_info[:org]).to eq 'prehnRA'
+    end
+
+    it 'should work with github https origin' do
+      allow(cli).to receive(:git_origin).and_return('https://github.com/prehnRA/lintron.git')
+      expect(cli.origin_info[:repo]).to eq 'lintron'
+      expect(cli.origin_info[:org]).to eq 'prehnRA'
+    end
+  end
+end

--- a/spec/lib/lintron/violation_line_spec.rb
+++ b/spec/lib/lintron/violation_line_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'lintron/api'
+
+describe Lintron::ViolationLine do
+  describe '#file_and_line' do
+    let(:with_line_info) do
+      Lintron::ViolationLine.new(message: 'you broke a rule', path: 'user.rb', line: 123)
+    end
+    let(:no_line_info) do
+      Lintron::ViolationLine.new(message: 'you broke a rule')
+    end
+
+    it 'should format line and path' do
+      base = 'user.rb:123    '
+      expect(with_line_info.file_and_line).to eq base
+
+      width = 30
+      expanded = base + ' ' * (width - base.length)
+      expect(with_line_info.file_and_line(width)).to eq expanded
+    end
+
+    it 'should work without line and path' do
+      expect(no_line_info.file_and_line).to eq ''
+      expect(no_line_info.file_and_line(30)).to eq(' ' * 30)
+    end
+  end
+end

--- a/spec/models/local_pr_alike_spec.rb
+++ b/spec/models/local_pr_alike_spec.rb
@@ -32,9 +32,9 @@ index dcf9ed7..8afc9c4 100644
     end
 
     it 'implements required methods' do
-      methods = %w[org repo files changed_files persisted? expected_url_from_path]
+      methods = %i[org repo files changed_files persisted? expected_url_from_path]
       methods.each do |method|
-        expect(LocalPrAlike.method_defined?(method.to_sym)).to be true
+        expect(LocalPrAlike.method_defined?(method)).to be true
       end
     end
   end

--- a/spec/models/local_pr_alike_spec.rb
+++ b/spec/models/local_pr_alike_spec.rb
@@ -30,5 +30,12 @@ index dcf9ed7..8afc9c4 100644
     it 'makes stub files from diff' do
       expect(pr.stubs_for_existing('origin/master').length).to eq 1
     end
+
+    it 'implements required methods' do
+      methods = %w[org repo files changed_files persisted? expected_url_from_path]
+      methods.each do |method|
+        expect(LocalPrAlike.method_defined?(method.to_sym)).to be true
+      end
+    end
   end
 end

--- a/spec/models/violation_spec.rb
+++ b/spec/models/violation_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Violation do
   describe '#as_json' do
-    it 'has path, line and message' do
+    it 'has path, line, message, and linter' do
       violation = Violation.new(
         file: OpenStruct.new(path: 'test.rb'),
         line: 1,
@@ -10,7 +10,7 @@ describe Violation do
       )
 
       expect do
-        expect(violation.as_json.keys).to eq [:path, :line, :message]
+        expect(violation.as_json.keys).to eq %i[path line message linter]
       end.to_not raise_error
     end
   end

--- a/spec/support/mocks/pull_requests.rb
+++ b/spec/support/mocks/pull_requests.rb
@@ -8,6 +8,10 @@ class MockPR
     'exemplar'
   end
 
+  def persisted?
+    false
+  end
+
   def expected_url_from_path(path)
     path
   end


### PR DESCRIPTION
- Add some required attributes to `LocalPrAlike` (org, repo, persisted?) These are used by the `SpecsRequired` linter.
- Handle pr-level violations that have no path and line in terminal reporting.

Also made a couple of changes to get tests passing: add `persisted?` to the mock PR fixture and expect `Violation#as_json` to return a `linter` attribute.