### PR TITLE
Pick up linter config files from the repo being linted

### DIFF
--- a/app/models/linter_config_file.rb
+++ b/app/models/linter_config_file.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# A config file for a particular linter, e.g. .eslintrc or .rubocop.yml
+# Can be created from a full filepath or a content blob
+# access #path or #content when using in linters
+class LinterConfigFile
+  def initialize(path: nil, content: nil)
+    raise ArgumentError, 'path or content must be provided' unless path || content
+    @path = path
+    @content = content
+  end
+
+  def self.from_path(file_path)
+    LinterConfigFile.new(path: file_path)
+  end
+
+  def self.from_content(content)
+    LinterConfigFile.new(content: content)
+  end
+
+  def content
+    @content ||= File.read(@path)
+  end
+
+  def path
+    @path ||= create_temp_file(@content)
+  end
+
+  def create_temp_file(content)
+    Tempfile.open('linter_config') do |file|
+      # keep a reference so the file does not get GC'd until this instance is gone
+      @tempfile = file
+      file.write(content)
+      file.path
+    end
+  end
+end

--- a/app/models/linters/base.rb
+++ b/app/models/linters/base.rb
@@ -1,9 +1,11 @@
-require_relative '../linters'
-
 module Linters
   # Defines the default relationship between the run_and_filter, run and
   # filter_messages methods of linters (i.e. don't filter any lints)
   class Base
+    def initialize(linter_config = nil)
+      @linter_config = linter_config
+    end
+
     def run_and_filter(file)
       filter_messages(run(file), file)
     end
@@ -11,5 +13,12 @@ module Linters
     def filter_messages(lints, _file)
       lints
     end
+
+    def self.config_filename
+      nil
+    end
   end
 end
+
+require_relative './js_linter'
+require_relative '../linters'

--- a/app/models/linters/coffee_lint.rb
+++ b/app/models/linters/coffee_lint.rb
@@ -1,13 +1,15 @@
 module Linters
   class CoffeeLint < Linters::JSLinter
-    CONFIG_PATH = Rails.root.join('coffeelint.json')
+    def self.config_path
+      Rails.root.join('coffeelint.json')
+    end
 
     def linter_name
       'CoffeeLint'
     end
 
     def config_contents
-      File.open(CONFIG_PATH) { |f| f.read }
+      File.open(self.class.config_path, &:read)
     end
 
     def linter_config

--- a/app/models/linters/es_lint.rb
+++ b/app/models/linters/es_lint.rb
@@ -25,13 +25,19 @@ module Linters
     end
 
     def cmd(file)
+      config = @linter_config ? ('-c ' + @linter_config.path) : ''
       <<-CMD.squish
         node_modules/eslint/bin/eslint.js
         -f json
         --stdin
         --stdin-filename #{file.path}
+        #{config}
         2>&1
       CMD
+    end
+
+    def self.config_filename
+      '.eslintrc'
     end
   end
 end

--- a/app/models/linters/js_linter.rb
+++ b/app/models/linters/js_linter.rb
@@ -1,19 +1,24 @@
 # An abstract linter that invokes a linter function written in JS using ExecJS
 module Linters
   class JSLinter < Linters::Base
-    SHIM_JS = Rails.root.join('src', 'envshim.js')
-    LINTER_JS = Rails.root.join('build', 'linters.js')
-
     def self.env
-      File.open(SHIM_JS) { |f| f.read }
+      File.open(shim_js, &:read)
     end
 
     def self.linters_source
-      @_linters_source ||= File.open(LINTER_JS) { |f| f.read }
+      @_linters_source ||= File.open(linter_js, &:read)
     end
 
     def self.context
       @_context ||= ExecJS.compile(env + linters_source)
+    end
+
+    def self.shim_js
+      Rails.root.join('src', 'envshim.js')
+    end
+
+    def self.linter_js
+      Rails.root.join('build', 'linters.js')
     end
 
     def fn_call_src(fn, *arguments)

--- a/app/models/linters/rubo_cop.rb
+++ b/app/models/linters/rubo_cop.rb
@@ -1,7 +1,9 @@
 class Linters::RuboCop < Linters::Base
   def run(file)
     return [] if ignored_file?(file)
-    runner = RuboCop::Runner.new({}, RuboCop::ConfigStore.new)
+    config = RuboCop::ConfigStore.new
+    config.options_config = @linter_config.path if @linter_config
+    runner = RuboCop::Runner.new({}, config)
     processed_source = processed_source_for(file)
     offenses, _ = runner.send(:inspect_file, processed_source)
     offenses.map { |o| Violation.new(file: file, line: o.location.line, message: o.message, linter: Linters::RuboCop) }
@@ -18,6 +20,10 @@ class Linters::RuboCop < Linters::Base
 
   def processed_source_for(file)
     RuboCop::ProcessedSource.new(file.blob, 2.3, file.path)
+  end
+
+  def self.config_filename
+    '.rubocop.yml'
   end
 end
 

--- a/app/models/local_pr_alike.rb
+++ b/app/models/local_pr_alike.rb
@@ -77,6 +77,7 @@ class LocalPrAlike
     path
   end
 
+  # return a LinterConfigFile if the repo has one matching this filename, or nil
   def get_config_file(filename)
     linter_configs[filename]
   end

--- a/app/models/local_pr_alike.rb
+++ b/app/models/local_pr_alike.rb
@@ -1,12 +1,13 @@
 require 'git_diff_parser'
 require_relative './stub_file'
 require_relative './patch'
+require_relative './linter_config_file'
 
 # An object that is similar enough to PullRequest to be linted. It can be
 # constructed from the CLI tool (compares local working tree to base_branch) or
 # from the JSON payload that the CLI tool sends to the API
 class LocalPrAlike
-  attr_accessor :files, :repo, :org
+  attr_accessor :files, :repo, :org, :linter_configs
 
   def self.from_json(params)
     LocalPrAlike.new.tap do |pr|
@@ -15,14 +16,18 @@ class LocalPrAlike
       pr.files = params[:files].map do |file_json|
         StubFile.from_json(file_json)
       end
+      pr.linter_configs = (params[:linter_configs] || {}).reduce({}) do |acc, (filename, content)|
+        acc.merge(filename => LinterConfigFile.from_content(content))
+      end
     end
   end
 
-  def self.from_branch(org, repo, base_branch)
+  def self.from_branch(org, repo, base_branch, repo_path)
     LocalPrAlike.new.tap do |pr|
       pr.org = org
       pr.repo = repo
       pr.files = pr.stubs_for_existing(base_branch) + pr.stubs_for_new
+      pr.load_linter_configs(repo_path)
     end
   end
 
@@ -72,6 +77,36 @@ class LocalPrAlike
     path
   end
 
+  def get_config_file(filename)
+    linter_configs[filename]
+  end
+
+  # a hash of file_name => LinterConfigFile
+  # for all linter configs pertaining to this PRs list of changed source files (StubFiles)
+  def load_linter_configs(repo_path)
+    extensions = files.map(&:extname).uniq
+    @linter_configs = extensions.reduce({}) do |linter_configs, extension|
+      linter_configs.merge(linter_configs_for(extension, repo_path))
+    end
+  end
+
+  def linter_configs_for(extension, repo_path)
+    Linters.linter_configs_for(extension).reduce({}) do |linter_configs, config_filename|
+      full_path = File.join(repo_path, config_filename)
+      if File.exist?(full_path)
+        linter_configs.merge(config_filename => LinterConfigFile.from_path(full_path))
+      else
+        linter_configs
+      end
+    end
+  end
+
+  def linter_configs_content
+    linter_configs.reduce({}) do |acc, (config_name, config_file)|
+      acc.merge(config_name => config_file.content)
+    end
+  end
+
   def files_as_json(_opts = {})
     @files.map(&:as_json)
   end
@@ -80,6 +115,7 @@ class LocalPrAlike
     {
       org: org,
       repo: repo,
+      linter_configs: linter_configs_content,
       files: files_as_json.select do |file_json|
         begin
           JSON.dump(file_json)

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -96,6 +96,7 @@ class PullRequest < ActiveRecord::Base
     end
   end
 
+  # return a LinterConfigFile if the repo has one matching this filename, or nil
   def get_config_file(filename)
     config_files[filename]
   end
@@ -108,17 +109,15 @@ class PullRequest < ActiveRecord::Base
   end
 
   def fetch_config_file(filename)
-    begin
-      response = Github.repos.contents.get(
-        user: org,
-        repo: repo,
-        path: filename,
-        ref: latest_commit.sha
-      )
-      LinterConfigFile.from_content(Base64.decode64(response.content))
-    rescue Github::Error::NotFound
-      nil
-    end
+    response = Github.repos.contents.get(
+      user: org,
+      repo: repo,
+      path: filename,
+      ref: latest_commit.sha,
+    )
+    LinterConfigFile.from_content(Base64.decode64(response.content))
+  rescue Github::Error::NotFound
+    nil
   end
 
   def expected_url_from_path(path)

--- a/lib/lintron/cli.rb
+++ b/lib/lintron/cli.rb
@@ -4,6 +4,12 @@ require 'active_support/all'
 require 'filewatcher'
 require_relative '../../app/models/local_pr_alike'
 
+# ./linters require some extra deps
+require 'brakeman'
+require_relative '../../app/models/linters/base'
+require_relative '../../app/models/linters/js_linter'
+require_relative '../../app/models/linters'
+
 module Lintron
   # Handles setting up flags for CLI runs based on defaults, linty_rc, and
   # command line arguments
@@ -48,7 +54,7 @@ module Lintron
     end
 
     def pr
-      LocalPrAlike.from_branch(org_name, repo_name, base_branch)
+      LocalPrAlike.from_branch(org_name, repo_name, base_branch, repo_path)
     end
 
     def base_branch

--- a/lib/tasks/pr_lint.rake
+++ b/lib/tasks/pr_lint.rake
@@ -1,0 +1,19 @@
+namespace :pr do
+  task :lint, [:url] => :environment do |task, args|
+    if args[:url] && PullRequest::PR_URL_PATTERN =~ args[:url]
+      pr = PullRequest.from_url(args[:url])
+      pr.lint_and_comment!
+    else
+      puts "Please provide the URL of a GitHub PR to lint"
+    end
+  end
+
+  task :lint_to_console, [:url] => :environment do |task, args|
+    if args[:url] && PullRequest::PR_URL_PATTERN =~ args[:url]
+      pr = PullRequest.from_url(args[:url])
+      puts Linters.violations_for_pr(pr).as_json
+    else
+      puts "Please provide the URL of a GitHub PR to lint"
+    end
+  end
+end

--- a/lib/tasks/pr_lint.rake
+++ b/lib/tasks/pr_lint.rake
@@ -1,5 +1,5 @@
 namespace :pr do
-  task :lint, [:url] => :environment do |task, args|
+  task :lint_and_comment, [:url] => :environment do |task, args|
     if args[:url] && PullRequest::PR_URL_PATTERN =~ args[:url]
       pr = PullRequest.from_url(args[:url])
       pr.lint_and_comment!

--- a/spec/models/linter_config_file_spec.rb
+++ b/spec/models/linter_config_file_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LinterConfigFile do
+  describe '#initialize' do
+    it 'requires a path or file content' do
+      expect do
+        LinterConfigFile.new
+      end.to raise_error
+    end
+
+    it 'saves a tmp file once if needed' do
+      config = LinterConfigFile.from_content('File Content')
+      first_path = config.path
+      expect(File.read(config.path)).to eq 'File Content'
+      expect(config.path).to eq first_path
+    end
+
+    it 'reads and caches content from a local file' do
+      path = Tempfile.open('temp') do |file|
+        file.write('File Content')
+        file.path
+      end
+      config = LinterConfigFile.from_path(path)
+      content = config.content
+      expect(content).to eq 'File Content'
+      File.unlink(path)
+      expect(config.content).to eq 'File Content'
+    end
+  end
+end

--- a/spec/models/local_pr_alike_spec.rb
+++ b/spec/models/local_pr_alike_spec.rb
@@ -38,4 +38,32 @@ index dcf9ed7..8afc9c4 100644
       end
     end
   end
+
+  describe '#load_linter_configs' do
+    let(:pr) do
+      LocalPrAlike.new.tap do |pr|
+        allow(pr).to receive(:files) { SampleStubFile.all }
+      end
+    end
+
+    it 'loads linter config files when found' do
+      allow(File).to receive(:exist?).and_return(true)
+      pr.load_linter_configs('/tmp')
+      expect(pr.get_config_file('.eslintrc').path).to eq('/tmp/.eslintrc')
+      expect(pr.get_config_file('.rubocop.yml').path).to eq('/tmp/.rubocop.yml')
+    end
+
+    it 'returns nil when linter configs are not found' do
+      allow(File).to receive(:exist?).and_return(false)
+      pr.load_linter_configs('/tmp')
+      expect(pr.get_config_file('.eslintrc')).to be(nil)
+      expect(pr.get_config_file('.rubocop.yml')).to be(nil)
+    end
+
+    it 'returns nil for configs associated with no linters' do
+      allow(File).to receive(:exist?).and_return(true)
+      pr.load_linter_configs('/tmp')
+      expect(pr.get_config_file('.no_such_linter')).to be(nil)
+    end
+  end
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -1,17 +1,52 @@
 require 'rails_helper'
 
 describe PullRequest do
+  let(:pr) do
+    pr = PullRequest.new(org: 'test-org', repo: 'test', pr_number: 123)
+    mock_commit = OpenStruct.new sha: 'deadbeef'
+    allow(pr).to receive(:latest_commit).and_return mock_commit
+    pr
+  end
+
   describe '#expected_url_from_path' do
     it 'returns a github url with the correct parts' do
-      pr = PullRequest.new(org: 'test-org', repo: 'test', pr_number: 123)
-      mock_commit = OpenStruct.new sha: 'deadbeef'
-      allow(pr).to receive(:latest_commit).and_return mock_commit
-
       expect do
         url = pr.expected_url_from_path('spec/models/post_spec.rb')
         expect(url).to include 'deadbeef' # sha
         expect(url).to include 'post_spec.rb' # filename
       end.to_not raise_error
+    end
+  end
+
+  describe '#get_config_file' do
+    let(:linter_config_file) { LinterConfigFile.from_content('configs in here') }
+
+    it 'returns a linter config file if it exists' do
+      allow(pr).to receive(:fetch_config_file).and_return(linter_config_file)
+      expect(pr.get_config_file('.eslintrc')).to be(linter_config_file)
+    end
+
+    it 'returns nil on a NotFound error' do
+      allow(Github.repos.contents).to receive(:get).and_throw(Github::Error::NotFound)
+      expect do
+        expect(pr.get_config_file('.eslintrc')).to be(nil)
+      end.not_to raise_error
+    end
+
+    it 'only fetches once for repeated access to a config file' do
+      allow(pr).to receive(:fetch_config_file).once.and_return(linter_config_file)
+      expect(pr.get_config_file('.eslintrc')).to be(linter_config_file)
+      expect(pr.get_config_file('.eslintrc')).to be(linter_config_file)
+      expect(pr.get_config_file('.eslintrc')).to be(linter_config_file)
+    end
+
+    it 'only fetches once if the config is not found' do
+      allow(pr).to receive(:fetch_config_file).once.and_return(nil)
+      expect do
+        expect(pr.get_config_file('.eslintrc')).to be(nil)
+        expect(pr.get_config_file('.eslintrc')).to be(nil)
+        expect(pr.get_config_file('.eslintrc')).to be(nil)
+      end.not_to raise_error
     end
   end
 end

--- a/spec/support/mocks/pull_requests.rb
+++ b/spec/support/mocks/pull_requests.rb
@@ -19,6 +19,10 @@ class MockPR
   def latest_commit
     OpenStruct.new sha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
   end
+
+  def get_config_file(_filename)
+    nil
+  end
 end
 
 class FixturePR < MockPR

--- a/spec/support/mocks/stub_file.rb
+++ b/spec/support/mocks/stub_file.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Sample stub files for testing PRs
+class SampleStubFile
+  def self.all
+    %w[index.js user.rb pull_request.rb linters.rb].map do |filename|
+      body = "body of #{filename}"
+      StubFile.new(
+        path: filename,
+        blob: body,
+        patch: Patch.from_file_body(body),
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds general support for custom linter config files, and implements them for Rubocop and Eslint. The other linters will still need slight modifications to make use of the custom configs in the repo.

Here are a couple of test PRs that have been linted with my test installation: https://github.com/grossvogel/lintron-test/pulls

There are a couple of things I had questions about:
* I ran into errors where the private variables (e.g. `@org` and `@repo` were not accessible in `PullRequest`, so I replaced them with getters. I don't think this will cause problems, but I wish I understood the source of the problem better.
* When I brought in `Linters` for use in the local version, I had errors with the load order of a few things. I ended up refactoring one or two things (e.g. to depend on Rails at runtime instead of load time) and rearranging some require statements. I think it works fine, I'm just not sure I handled it in the best way.