### PR TITLE
Do not attempt to fetch a nil / empty string config filename from Github

### DIFF
--- a/app/models/linters/scss_lint.rb
+++ b/app/models/linters/scss_lint.rb
@@ -6,7 +6,8 @@ module Linters
       ::SCSSLint::Config::FILE_NAME
     end
 
-    def initialize
+    def initialize(linter_config = nil)
+      @linter_config = linter_config
       add_suit
     end
 

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -109,7 +109,7 @@ class PullRequest < ActiveRecord::Base
   end
 
   def fetch_config_file(filename)
-    return nil unless filename
+    return nil if filename.to_s.empty?
 
     response = Github.repos.contents.get(
       user: org,

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -109,6 +109,8 @@ class PullRequest < ActiveRecord::Base
   end
 
   def fetch_config_file(filename)
+    return nil unless filename
+
     response = Github.repos.contents.get(
       user: org,
       repo: repo,

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -33,6 +33,13 @@ describe PullRequest do
       end.not_to raise_error
     end
 
+    it 'does not try to fetch nil config file from github' do
+      expect(Github.repos.contents).to_not receive(:get)
+      expect do
+        expect(pr.get_config_file(nil)).to be(nil)
+      end.not_to raise_error
+    end
+
     it 'only fetches once for repeated access to a config file' do
       allow(pr).to receive(:fetch_config_file).once.and_return(linter_config_file)
       expect(pr.get_config_file('.eslintrc')).to be(linter_config_file)


### PR DESCRIPTION
This should fix the bug where we try to pass a nil path to the Github API.
Also fixed an issue with the SCSS linter, caused by the fact that it declared its own `initialize`.