### PR TITLE
Ignore moduledoc lint for Test modules

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -79,7 +79,10 @@
         {Credo.Check.Readability.LargeNumbers},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
         {Credo.Check.Readability.ModuleAttributeNames},
-        {Credo.Check.Readability.ModuleDoc},
+        {Credo.Check.Readability.ModuleDoc, ignore_names: [
+          ~r/(\.\w+Controller|\.Endpoint|\.Repo|\.Router|\.\w+Socket|\.\w+View)$/, # Default ignore regex
+          ~r/\.Test$/ # Ignore Test modules
+        ]},
         {Credo.Check.Readability.ModuleNames},
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
         {Credo.Check.Readability.ParenthesesInCondition},


### PR DESCRIPTION
Makes it so test modules are ignored from moduledoc lint. Targets modules that have names that end in `Test`.