### PR TITLE
Patch to skip files with zero changes for linting

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -55,7 +55,7 @@ class PullRequest < ActiveRecord::Base
       page = 1
       files_tmp = []
       loop do
-        files = fetch_file_page(page)
+        files = fetch_file_page(page).select { |f| f.changes.positive? }
         files_tmp.concat(files)
         break if files.length == 0
         page += 1


### PR DESCRIPTION
Files with no changes don't get a `sha` and the code below was causing exception for these kind of files, when looping for linting. This patch skips the files with no changes and avoids any exception therefore.

```ruby
# app/models/github_file.rb
def blob
  cache_api_request :blob do
    Base64
      .decode64(Github.git_data.blobs.get(org, repo, to_gh.sha).content) # problem was here
      .encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')
  end
end
```