### PR TITLE
Fixes to make Lintron work locally again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,4 @@ group :test do
 end
 
 # Access an IRB console on exception pages or by using <%= console %> in views
-gem 'web-console', '~> 2.0', group: 'development'
+gem 'web-console', '~> 3.5.1', group: 'development'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,7 @@ GEM
     arel (9.0.0)
     ast (2.3.0)
     bcrypt (3.1.11)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
+    bindex (0.5.0)
     brakeman (3.6.2)
     breakpoint (2.7.1)
       sass (~> 3.3)
@@ -61,7 +60,6 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
-    debug_inspector (0.0.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.4.3)
@@ -268,11 +266,11 @@ GEM
     unicode-display_width (1.2.1)
     warden (1.2.7)
       rack (>= 1.0)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (3.5.1)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -316,7 +314,7 @@ DEPENDENCIES
   sqlite3
   therubyracer
   uglifier (>= 1.3.0)
-  web-console (~> 2.0)
+  web-console (~> 3.5.1)
 
 RUBY VERSION
    ruby 2.3.3p222

--- a/app/controllers/local_lints_controller.rb
+++ b/app/controllers/local_lints_controller.rb
@@ -4,7 +4,7 @@ class LocalLintsController < ApplicationController
   skip_before_action :verify_authenticity_token, if: :json_request?
 
   def create
-    pr = LocalPrAlike.from_json(params)
+    pr = LocalPrAlike.from_json(local_pr_params)
     violations = Linters.violations_for_pr(pr)
 
     render json: violations
@@ -14,5 +14,14 @@ class LocalLintsController < ApplicationController
 
   def json_request?
     request.format.json?
+  end
+
+  def local_pr_params
+    params.permit(
+      :org,
+      :repo,
+      linter_configs: {},
+      files: %i[blob patch path],
+    )
   end
 end

--- a/app/models/local_pr_alike.rb
+++ b/app/models/local_pr_alike.rb
@@ -16,7 +16,8 @@ class LocalPrAlike
       pr.files = params[:files].map do |file_json|
         StubFile.from_json(file_json)
       end
-      pr.linter_configs = (params[:linter_configs] || {}).reduce({}) do |acc, (filename, content)|
+      linter_configs = (params[:linter_configs] || {}).to_h
+      pr.linter_configs = linter_configs.reduce({}) do |acc, (filename, content)|
         acc.merge(filename => LinterConfigFile.from_content(content))
       end
     end


### PR DESCRIPTION
* Update the `web-console` version
* Update param handling to work with the current Rails version (permit before `to_h`)